### PR TITLE
Refactor currency units

### DIFF
--- a/src/main/scala/org/bitcoins/core/consensus/Consensus.scala
+++ b/src/main/scala/org/bitcoins/core/consensus/Consensus.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.core.consensus
 
-import org.bitcoins.core.currency.{Bitcoins, CurrencyUnit}
+import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
+import org.bitcoins.core.number.Int64
 
 /**
   * Created by chris on 5/13/16.
@@ -9,7 +10,7 @@ trait Consensus {
 
   def maxBlockSize = 1000000
 
-  def maxMoney : CurrencyUnit = Bitcoins(21000000)
+  def maxMoney : CurrencyUnit = Satoshis(Int64(2100000000000000L))
 }
 
 object Consensus extends Consensus

--- a/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
+++ b/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
@@ -61,10 +61,8 @@ object Satoshis extends Factory[Satoshis] with BaseNumbers[Satoshis] {
 }
 
 object CurrencyUnits {
-  def zero : CurrencyUnit = zeroSatoshis
+  def zero : CurrencyUnit = Satoshis.zero
   def negativeSatoshi = Satoshis(Int64(-1))
-  def zeroSatoshis = Satoshis(Int64.zero)
-  def oneSatoshi = Satoshis(Int64.one)
 
   def toSatoshis(unit : CurrencyUnit): Satoshis = unit match {
     case x : Satoshis => x

--- a/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
+++ b/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
@@ -1,121 +1,72 @@
 package org.bitcoins.core.currency
 
-import scala.math.BigDecimal.RoundingMode
+import org.bitcoins.core.number.{BaseNumbers, Int32, Int64, SignedNumber}
+import org.bitcoins.core.protocol.NetworkElement
+import org.bitcoins.core.serializers.{RawBitcoinSerializerHelper, RawSatoshisSerializer}
+import org.bitcoins.core.util.{BitcoinSLogger, Factory}
 
-abstract class CurrencyUnit(val value:Double) {
-  def toStringWithoutCurrencyLabel : String = CurrencyUnits.currencyFormatter(value)
-  def ==(c : CurrencyUnit) : Boolean = {
-    /*require (c != null, "Currency units cannot be null")*/
-    CurrencyUnits.toSatoshis(this).value == CurrencyUnits.toSatoshis(c).value
-  }
+
+sealed trait CurrencyUnit extends NetworkElement with BitcoinSLogger {
+  type A
+  def underlying : A
 
   def >=(c : CurrencyUnit) : Boolean = {
-    CurrencyUnits.toSatoshis(this).value >= CurrencyUnits.toSatoshis(c).value
+    CurrencyUnits.toSatoshis(this).underlying >= CurrencyUnits.toSatoshis(c).underlying
   }
 
   def >(c : CurrencyUnit) : Boolean = {
-    CurrencyUnits.toSatoshis(this).value > CurrencyUnits.toSatoshis(c).value
+    CurrencyUnits.toSatoshis(this).underlying > CurrencyUnits.toSatoshis(c).underlying
   }
 
   def <(c : CurrencyUnit) : Boolean = {
-    CurrencyUnits.toSatoshis(this).value < CurrencyUnits.toSatoshis(c).value
+    CurrencyUnits.toSatoshis(this).underlying < CurrencyUnits.toSatoshis(c).underlying
   }
 
   def <=(c : CurrencyUnit) : Boolean = {
-    /*require (c != null, "Currency units cannot be null")*/
-    CurrencyUnits.toSatoshis(this).value <= CurrencyUnits.toSatoshis(c).value
+    CurrencyUnits.toSatoshis(this).underlying <= CurrencyUnits.toSatoshis(c).underlying
   }
 
-  def !=(c : CurrencyUnit) : Boolean = {
-    !(this == c)
-  }
+  def !=(c : CurrencyUnit) : Boolean = !(this == c)
+
 
   def +(c : CurrencyUnit) : CurrencyUnit = {
-    Satoshis(CurrencyUnits.toSatoshis(this).value + CurrencyUnits.toSatoshis(c).value)
+    Satoshis(CurrencyUnits.toSatoshis(this).underlying + CurrencyUnits.toSatoshis(c).underlying)
   }
 
   def -(c : CurrencyUnit) : CurrencyUnit = {
-    Satoshis(CurrencyUnits.toSatoshis(this).value - CurrencyUnits.toSatoshis(c).value)
+    Satoshis(CurrencyUnits.toSatoshis(this).underlying - CurrencyUnits.toSatoshis(c).underlying)
   }
 
   def *(c : CurrencyUnit) : CurrencyUnit = {
-    Satoshis(CurrencyUnits.toSatoshis(this).value * CurrencyUnits.toSatoshis(c).value)
+    Satoshis(CurrencyUnits.toSatoshis(this).underlying * CurrencyUnits.toSatoshis(c).underlying)
   }
 }
 
-case class Satoshis(override val value: Double) extends CurrencyUnit(value) {
-  require(value.isWhole, "The satoshis constructor cannot be a double with decimal places, satoshis are the smallest currency unit in bitcoin")
-  override def toString = toStringWithoutCurrencyLabel + " Satoshis"
-  override def toStringWithoutCurrencyLabel = value.toLong.toString
+sealed trait Satoshis extends CurrencyUnit {
+  override type A = Int64
+  override def hex = RawSatoshisSerializer.write(this)
 }
 
-case class Bits(override val value: Double) extends CurrencyUnit(value) {
-  override def toString = toStringWithoutCurrencyLabel + " Bits"
-}
+object Satoshis extends Factory[Satoshis] with BaseNumbers[Satoshis] {
+  private case class SatoshisImpl(underlying : Int64) extends Satoshis
 
-case class Bitcoins(override val value: Double) extends CurrencyUnit(value) {
-  override def toString =  toStringWithoutCurrencyLabel + " BTC"
-}
+  def min = Satoshis(Int64.min)
+  def max = Satoshis(Int64.max)
+  def zero = Satoshis(Int64.zero)
+  def one = Satoshis(Int64.one)
 
-case class MilliBitcoins(override val value : Double) extends CurrencyUnit(value) {
-  override def toString = toStringWithoutCurrencyLabel + " mBTC"
+  override def fromBytes(bytes : Seq[Byte]): Satoshis = RawSatoshisSerializer.read(bytes)
+
+  def apply(int64: Int64): Satoshis = SatoshisImpl(int64)
 }
 
 object CurrencyUnits {
   def zero : CurrencyUnit = zeroSatoshis
-  def negativeSatoshi = Satoshis(-1)
-  def zeroSatoshis = Satoshis(0)
-  def oneSatoshi = Satoshis(1)
-  def oneMilliBit = Satoshis(100000)
-  def tenMilliBits = Satoshis(1000000)
-  def oneHundredMilliBits = Satoshis(10000000)
+  def negativeSatoshi = Satoshis(Int64(-1))
+  def zeroSatoshis = Satoshis(Int64.zero)
+  def oneSatoshi = Satoshis(Int64.one)
 
-  def oneBTC = Bitcoins(1)
-
-  /*considering the scalar for a 1 BTC to be 1*/
-  val satoshiScalar = 0.00000001
-  val bitsScalar = 0.000001
-  val bitcoinScalar = 1
-  val milliBitcoinScalar = 0.001
-
-  def satoshisToBits(satoshis: Satoshis): Bits = {
-    Bits((satoshis.value * satoshiScalar) / bitsScalar)
-  }
-  def sataoshisToBitcoin(satoshis: Satoshis): Bitcoins = {
-    Bitcoins(satoshis.value * satoshiScalar)
-  }
-
-  def bitsToSatoshis(bits: Bits): Satoshis = {
-    Satoshis((bits.value * (bitsScalar / satoshiScalar)).toLong)
-  }
-
-  def bitsToBitcoins(bits: Bits): Bitcoins = {
-    Bitcoins((bits.value * bitsScalar) / bitcoinScalar)
-  }
-
-  def bitcoinsToSatoshis(bitcoins: Bitcoins): Satoshis = {
-
-    Satoshis((bitcoins.value / satoshiScalar).toLong)
-  }
-
-  def bitcoinsToBits(bitcoins: Bitcoins): Bits = {
-    Bits((bitcoinScalar * bitcoins.value) / bitsScalar)
-  }
-
-  def milliBitcoinsToSatoshis(milliBits : MilliBitcoins) = {
-    Satoshis((milliBits.value * (milliBitcoinScalar / satoshiScalar)).toLong)
-  }
-  def currencyFormatter(value : Double) = {
-
-    if (value == 0) "0" else "%.5f".format(BigDecimal(value).setScale(5, RoundingMode.CEILING)).replaceAll("[.0]*$","")
-  }
-
-  def toSatoshis(unit : CurrencyUnit) = {
-    unit match {
-      case x : Bitcoins => bitcoinsToSatoshis(x)
-      case x : Bits => bitsToSatoshis(x)
-      case x : MilliBitcoins => milliBitcoinsToSatoshis(x)
-      case x : Satoshis => x
-    }
+  def toSatoshis(unit : CurrencyUnit): Satoshis = unit match {
+    case x : Satoshis => x
   }
 }

--- a/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -236,9 +236,9 @@ object UnsignedNumber extends Factory[UnsignedNumber] {
 
 /**
   * Represents various numbers that should be implemented
-  * inside of any companion object for a [[Number]]
+  * inside of any companion object for a number
   */
-trait BaseNumbers[T <: Number] {
+trait BaseNumbers[T] {
   def zero : T
   def one : T
   def min : T

--- a/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
@@ -2,7 +2,8 @@ package org.bitcoins.core.protocol.blockchain
 
 import org.bitcoins.core.consensus.Merkle
 import org.bitcoins.core.crypto.DoubleSha256Digest
-import org.bitcoins.core.currency.{Bitcoins, CurrencyUnit}
+import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
+import org.bitcoins.core.number.Int64
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.script.{ScriptPubKey, ScriptSignature}
 import org.bitcoins.core.protocol.transaction.{Transaction, TransactionConstants, TransactionInput, TransactionOutput}
@@ -114,7 +115,7 @@ object MainNetChainParams extends ChainParams {
 
   override def networkId = "main"
 
-  override def genesisBlock = createGenesisBlock(1231006505, 2083236893, 0x1d00ffff, 1, Bitcoins(50))
+  override def genesisBlock = createGenesisBlock(1231006505, 2083236893, 0x1d00ffff, 1, Satoshis(Int64(5000000000L)))
 
   override def requireStandardTransaction = true
 
@@ -137,7 +138,7 @@ object TestNetChainParams extends ChainParams {
 
   override def networkId = "test"
 
-  override def genesisBlock = createGenesisBlock(1296688602, 414098458, 0x1d00ffff, 1, Bitcoins(50))
+  override def genesisBlock = createGenesisBlock(1296688602, 414098458, 0x1d00ffff, 1, Satoshis(Int64(5000000000L)))
 
   override def requireStandardTransaction = true
 
@@ -159,7 +160,7 @@ object TestNetChainParams extends ChainParams {
 
 object RegTestNetChainParams extends ChainParams {
   override def networkId = "regtest"
-  override def genesisBlock = createGenesisBlock(1296688602, 2, 0x207fffff, 1, Bitcoins(50))
+  override def genesisBlock = createGenesisBlock(1296688602, 2, 0x207fffff, 1, Satoshis(Int64(5000000000L)))
   override def requireStandardTransaction = TestNetChainParams.requireStandardTransaction
 
   /**

--- a/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -253,7 +253,7 @@ object ScriptPubKey extends Factory[ScriptPubKey] with BitcoinSLogger {
   private def isMultiSignatureScriptPubKey(asm : Seq[ScriptToken]) : Boolean = {
 
     val isNotEmpty = asm.size > 0
-    val containsMultSigOp = asm.contains(OP_CHECKMULTISIG) || asm.contains(OP_CHECKMULTISIGVERIFY)
+    val containsMultiSigOp = asm.contains(OP_CHECKMULTISIG) || asm.contains(OP_CHECKMULTISIGVERIFY)
     //we need either the first or second asm operation to indicate how many signatures are required
     val hasRequiredSignaturesTry = Try {
       asm.headOption match {
@@ -277,10 +277,8 @@ object ScriptPubKey extends Factory[ScriptPubKey] with BitcoinSLogger {
     logger.info("Non standard ops: " + standardOps)
     (hasRequiredSignaturesTry, hasMaximumSignaturesTry) match {
       case (Success(hasRequiredSignatures), Success(hasMaximumSignatures)) =>
-        logger.info("Has required signatures: " + hasRequiredSignatures)
-        logger.info("Has maximum signatures: " + hasMaximumSignatures)
-        val result = isNotEmpty && containsMultSigOp && hasRequiredSignatures && hasMaximumSignatures && standardOps.size == asm.size
-        logger.info("Result: " + result)
+        val result = isNotEmpty && containsMultiSigOp && hasRequiredSignatures &&
+          hasMaximumSignatures && standardOps.size == asm.size
         result
       case (Success(_), Failure(_)) => false
       case (Failure(_), Success(_)) => false

--- a/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -4,21 +4,20 @@ package org.bitcoins.core.script.interpreter
 import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits}
 import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.protocol.transaction.{EmptyTransactionOutPoint, Transaction, TransactionOutput}
-import org.bitcoins.core.script.flag._
-import org.bitcoins.core.script.locktime.{LockTimeInterpreter, OP_CHECKLOCKTIMEVERIFY, OP_CHECKSEQUENCEVERIFY}
-import org.bitcoins.core.script.splice._
+import org.bitcoins.core.protocol.transaction.{EmptyTransactionOutPoint, Transaction}
 import org.bitcoins.core.script._
 import org.bitcoins.core.script.arithmetic._
 import org.bitcoins.core.script.bitwise._
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.control._
 import org.bitcoins.core.script.crypto._
+import org.bitcoins.core.script.flag._
+import org.bitcoins.core.script.locktime.{LockTimeInterpreter, OP_CHECKLOCKTIMEVERIFY, OP_CHECKSEQUENCEVERIFY}
 import org.bitcoins.core.script.reserved._
+import org.bitcoins.core.script.result._
+import org.bitcoins.core.script.splice._
 import org.bitcoins.core.script.stack._
 import org.bitcoins.core.util.{BitcoinSLogger, BitcoinScriptUtil}
-import org.bitcoins.core.script.result._
-import org.slf4j.LoggerFactory
 
 import scala.annotation.tailrec
 
@@ -385,7 +384,7 @@ trait ScriptInterpreter extends CryptoInterpreter with StackInterpreter with Con
     //TODO: replace 1000000 with a value that represents the max block size
     val txNotLargerThanBlock = transaction.bytes.size < Consensus.maxBlockSize
     val outputsSpendValidAmountsOfMoney = !transaction.outputs.exists(o =>
-      o.value < CurrencyUnits.zeroSatoshis || o.value > Consensus.maxMoney)
+      o.value < CurrencyUnits.zero || o.value > Consensus.maxMoney)
 
     val outputValues = transaction.outputs.map(_.value)
     val totalSpentByOutputs : CurrencyUnit = outputValues.fold(CurrencyUnits.zero)(_ + _)
@@ -412,7 +411,7 @@ trait ScriptInterpreter extends CryptoInterpreter with StackInterpreter with Con
     * @return
     */
   def validMoneyRange(currencyUnit : CurrencyUnit) : Boolean = {
-    currencyUnit >= CurrencyUnits.zeroSatoshis && currencyUnit <= Consensus.maxMoney
+    currencyUnit >= CurrencyUnits.zero && currencyUnit <= Consensus.maxMoney
   }
 
 

--- a/src/main/scala/org/bitcoins/core/serializers/RawSatoshisSerializer.scala
+++ b/src/main/scala/org/bitcoins/core/serializers/RawSatoshisSerializer.scala
@@ -1,0 +1,16 @@
+package org.bitcoins.core.serializers
+
+import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.number.Int64
+
+/**
+  * Created by chris on 6/23/16.
+  */
+trait RawSatoshisSerializer extends RawBitcoinSerializer[Satoshis] {
+
+  def read(bytes : List[Byte]): Satoshis = Satoshis(Int64(bytes))
+
+  def write(satoshis: Satoshis): String = satoshis.underlying.hex
+}
+
+object RawSatoshisSerializer extends RawSatoshisSerializer

--- a/src/main/scala/org/bitcoins/core/serializers/transaction/RawTransactionOutputParser.scala
+++ b/src/main/scala/org/bitcoins/core/serializers/transaction/RawTransactionOutputParser.scala
@@ -1,10 +1,10 @@
 package org.bitcoins.core.serializers.transaction
 
 import org.bitcoins.core.currency.{CurrencyUnits, Satoshis}
-import org.bitcoins.core.serializers.RawBitcoinSerializer
+import org.bitcoins.core.serializers.{RawBitcoinSerializer, RawSatoshisSerializer}
 import org.bitcoins.core.serializers.script.{RawScriptPubKeyParser, ScriptParser}
 import org.bitcoins.core.protocol.CompactSizeUInt
-import org.bitcoins.core.protocol.transaction.{TransactionOutputImpl, TransactionOutput}
+import org.bitcoins.core.protocol.transaction.{TransactionOutput, TransactionOutputImpl}
 import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil}
 import org.slf4j.LoggerFactory
 
@@ -66,7 +66,7 @@ trait RawTransactionOutputParser extends RawBitcoinSerializer[Seq[TransactionOut
   def write(output : TransactionOutput) : String = {
     val satoshis = CurrencyUnits.toSatoshis(output.value)
     val compactSizeUIntHex = output.scriptPubKeyCompactSizeUInt.hex
-    val satoshisHexWithoutPadding : String = BitcoinSUtil.encodeHex(satoshis)
+    val satoshisHexWithoutPadding : String = BitcoinSUtil.flipEndianess(satoshis.hex)
     val satoshisHex = addPadding(16,satoshisHexWithoutPadding)
     logger.debug("compactSizeUIntHex: " + compactSizeUIntHex)
     logger.debug("satoshis: " + satoshisHex)
@@ -80,12 +80,7 @@ trait RawTransactionOutputParser extends RawBitcoinSerializer[Seq[TransactionOut
     * @param hex the hex string that is being parsed to satoshis
     * @return the value of the hex string in satoshis
     */
-  private def parseSatoshis(hex : String) : Satoshis = {
-    if (hex == "ffffffffffffffff") {
-      //this represents a negative satoshis
-      CurrencyUnits.negativeSatoshi
-    } else Satoshis(java.lang.Long.parseLong(hex, 16))
-  }
+  private def parseSatoshis(hex : String) : Satoshis = RawSatoshisSerializer.read(hex)
 }
 
 

--- a/src/main/scala/org/bitcoins/core/util/BitcoinSUtil.scala
+++ b/src/main/scala/org/bitcoins/core/util/BitcoinSUtil.scala
@@ -1,8 +1,5 @@
 package org.bitcoins.core.util
 
-import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits}
-import org.bitcoins.core.serializers.RawBitcoinSerializerHelper
-
 import scala.math.BigInt
 
 /**
@@ -15,16 +12,6 @@ trait BitcoinSUtil {
   }
 
   def encodeHex(bytes : Seq[Byte]) : String = bytes.map("%02x".format(_)).mkString
-
-  def encodeHex(unit : CurrencyUnit) : String = {
-    val satoshis = CurrencyUnits.toSatoshis(unit)
-    if (satoshis == CurrencyUnits.negativeSatoshi) {
-      "ffffffffffffffff"
-    } else {
-      //TODO: this is ugly, clean this up. Shouldn't have to use .toLong
-      flipEndianess(BigInt(satoshis.value.toLong).toByteArray)
-    }
-  }
 
   def encodeHex(byte : Byte) : String = encodeHex(Seq(byte))
 

--- a/src/test/scala/org/bitcoins/core/currency/CurrencyUnitGenerator.scala
+++ b/src/test/scala/org/bitcoins/core/currency/CurrencyUnitGenerator.scala
@@ -1,0 +1,18 @@
+package org.bitcoins.core.currency
+
+import org.bitcoins.core.number.{Int64, NumberGenerator}
+import org.scalacheck.Gen
+
+/**
+  * Created by chris on 6/23/16.
+  */
+trait CurrencyUnitGenerator {
+
+  def satoshis : Gen[Satoshis] = for {
+    int64 <- NumberGenerator.int64s
+  } yield Satoshis(int64)
+
+}
+
+
+object CurrencyUnitGenerator extends CurrencyUnitGenerator

--- a/src/test/scala/org/bitcoins/core/currency/CurrencyUnitSpec.scala
+++ b/src/test/scala/org/bitcoins/core/currency/CurrencyUnitSpec.scala
@@ -1,0 +1,79 @@
+package org.bitcoins.core.currency
+
+import org.scalacheck.{Prop, Properties}
+
+import scala.util.Try
+
+/**
+  * Created by chris on 6/23/16.
+  */
+class CurrencyUnitSpec extends Properties("CurrencyUnitSpec") {
+
+  property("Symmetrical serialization for satoshis") =
+    Prop.forAll(CurrencyUnitGenerator.satoshis) { satoshis =>
+      Satoshis(satoshis.hex) == satoshis
+    }
+
+  property("additive identity") =
+    Prop.forAll(CurrencyUnitGenerator.satoshis) { satoshis =>
+      satoshis + CurrencyUnits.zero == satoshis
+    }
+
+  property("add two satoshis") =
+    Prop.forAll(CurrencyUnitGenerator.satoshis, CurrencyUnitGenerator.satoshis) { (num1 : Satoshis, num2 : Satoshis) =>
+      val result = num1.underlying + num2.underlying
+      if (result >= Satoshis.min.underlying &&
+        result <= Satoshis.max.underlying) num1 + num2 == Satoshis(result)
+      else Try(num1 + num2).isFailure
+    }
+
+  property("Subtractive identity for satoshis") =
+    Prop.forAll(CurrencyUnitGenerator.satoshis) { satoshis =>
+      satoshis - CurrencyUnits.zero == satoshis
+    }
+
+  property("Subtract two satoshi values") =
+    Prop.forAll(CurrencyUnitGenerator.satoshis, CurrencyUnitGenerator.satoshis) { (num1 : Satoshis, num2 : Satoshis) =>
+      val result = num1.underlying - num2.underlying
+      if (result >= Satoshis.min.underlying &&
+        result <= Satoshis.max.underlying) num1 - num2 == Satoshis(result)
+      else Try(num1 - num2).isFailure
+    }
+
+  property("Multiply satoshis by zero") =
+    Prop.forAll(CurrencyUnitGenerator.satoshis) { satoshis =>
+      satoshis * CurrencyUnits.zero == CurrencyUnits.zero
+    }
+
+  property("Multiplicative identity") =
+    Prop.forAll(CurrencyUnitGenerator.satoshis) { satoshis =>
+      satoshis * CurrencyUnits.oneSatoshi == satoshis
+
+    }
+
+  property("Multiply two satoshi values") =
+    Prop.forAll(CurrencyUnitGenerator.satoshis, CurrencyUnitGenerator.satoshis) { (num1 : Satoshis, num2 : Satoshis) =>
+      val result = num1.underlying * num2.underlying
+      if (result >= Satoshis.min.underlying &&
+        result <= Satoshis.max.underlying) num1 * num2 == Satoshis(result)
+      else Try(num1 * num2).isFailure
+    }
+
+  property("< & >=") =
+    Prop.forAll(CurrencyUnitGenerator.satoshis, CurrencyUnitGenerator.satoshis) { (num1 : Satoshis, num2 : Satoshis) =>
+      (num1 < num2) || (num1 >= num2)
+    }
+
+  property("<= & >") =
+    Prop.forAll(CurrencyUnitGenerator.satoshis, CurrencyUnitGenerator.satoshis) { (num1 : Satoshis, num2 : Satoshis) =>
+      (num1 <= num2) || (num1 > num2)
+    }
+
+  property("== & !=") =
+    Prop.forAll(CurrencyUnitGenerator.satoshis, CurrencyUnitGenerator.satoshis) { (num1 : Satoshis, num2 : Satoshis) =>
+      (num1 == num2) || (num1 != num2)
+    }
+
+}
+
+

--- a/src/test/scala/org/bitcoins/core/currency/CurrencyUnitSpec.scala
+++ b/src/test/scala/org/bitcoins/core/currency/CurrencyUnitSpec.scala
@@ -47,7 +47,7 @@ class CurrencyUnitSpec extends Properties("CurrencyUnitSpec") {
 
   property("Multiplicative identity") =
     Prop.forAll(CurrencyUnitGenerator.satoshis) { satoshis =>
-      satoshis * CurrencyUnits.oneSatoshi == satoshis
+      satoshis * Satoshis.one == satoshis
 
     }
 

--- a/src/test/scala/org/bitcoins/core/currency/CurrencyUnitsTest.scala
+++ b/src/test/scala/org/bitcoins/core/currency/CurrencyUnitsTest.scala
@@ -1,149 +1,19 @@
 package org.bitcoins.core.currency
 
 
-import org.scalatest.{MustMatchers, Matchers, FlatSpec}
+import org.bitcoins.core.number.{Int32, Int64}
+import org.scalatest.{FlatSpec, Matchers, MustMatchers}
 
 /**
  * Created by chris on 12/21/15.
  */
-
-
 class CurrencyUnitsTest extends FlatSpec with MustMatchers {
-
-  "One satoshi" should ("be equivalent to  0.00000001 BTC") in {
-    CurrencyUnits.sataoshisToBitcoin(Satoshis(1)).value must be  (0.00000001)
+  "CurrencyUnits" must "have the correct amount for the max amount of satoshis" in {
+    Satoshis.max.underlying must be (Int64.max)
   }
 
-  "One satoshi" should ("be equivalent to 0.001 bits") in {
-    CurrencyUnits.satoshisToBits(Satoshis(1)).value must be (0.01)
-  }
-
-  "One bit" should ("be equivalent to 100 Satoshis") in {
-    CurrencyUnits.bitsToSatoshis(Bits(1)).value must be (100)
-  }
-
-  "One bit" should ("be equivalent to 0.000001 BTC") in {
-    CurrencyUnits.bitsToBitcoins(Bits(1)).value must be (0.000001)
-  }
-
-  "One bitcoin" should ("be equivalent to 100,000,000 Satoshis") in {
-    CurrencyUnits.bitcoinsToSatoshis(Bitcoins(1)).value must be (100000000)
-  }
-
-  "One bitcoin" should ("be equivalent to 1,000,000 bits") in {
-    CurrencyUnits.bitcoinsToBits(Bitcoins(1)).value must be (1000000)
-  }
-
-  "The conversion of 1 BTC -> Bits -> Satoshis" should ("equivalent to BTC -> Satoshis") in {
-    val btcToBitsToSatoshis = CurrencyUnits.bitsToSatoshis(CurrencyUnits.bitcoinsToBits(Bitcoins(1)))
-    val btcToSatoshis = CurrencyUnits.bitcoinsToSatoshis(Bitcoins(1))
-
-    btcToBitsToSatoshis.value must be (btcToSatoshis.value)
-  }
-
-  "The conversion of 100,000,000 Satoshis -> Bits -> BTC" should ("be equivalent to 100,000,000 Satoshis -> BTC") in {
-    val satoshisToBitsToBTC = CurrencyUnits.bitsToBitcoins(CurrencyUnits.satoshisToBits(Satoshis(100000000)))
-    val satoshisToBTC = CurrencyUnits.sataoshisToBitcoin(Satoshis(100000000))
-    satoshisToBTC.value must be (satoshisToBitsToBTC.value)
-  }
-
-  "The conversion of 1,000,000 Bits -> Satoshis -> BTC" should ("be equivalent to 1,000,000 Bits -> BTC") in {
-    val bits = Bits(1000000)
-    val bitsToSatoshisToBTC = CurrencyUnits.sataoshisToBitcoin(CurrencyUnits.bitsToSatoshis(bits))
-    val bitsToBTC = CurrencyUnits.bitsToBitcoins(bits)
-    bitsToSatoshisToBTC.value must be (bitsToBTC.value)
-  }
-
-  it must "convert bitcoins to satoshies" in {
-    val bitcoins = Bitcoins(0.75)
-    val expectedValue = Satoshis(75000000)
-    CurrencyUnits.bitcoinsToSatoshis(bitcoins) must be (expectedValue)
-  }
-
-  it must "convert bits to satoshies" in {
-    val bits = Bits(75)
-    val expectedValue = Satoshis(7500)
-    CurrencyUnits.bitsToSatoshis(bits) must be (expectedValue)
-  }
-
-  it must "convert bitcoins to bits" in {
-    val bitcoins = Bitcoins(0.75)
-    val expectedValue = Bits(750000)
-    CurrencyUnits.bitcoinsToBits(bitcoins) must be (expectedValue)
-  }
-
-  it must "display bitcoins correctly" in {
-    val bitcoins = Bitcoins(1.23423523523526)
-    bitcoins.toString must be ("1.23424 BTC")
-
-    val bitcoinsRoundUp = Bitcoins(5.2321223523623)
-    bitcoinsRoundUp.toString must be ("5.23213 BTC")
-
-    val roundBitcoins = Bitcoins(2.0)
-    roundBitcoins.toString must be("2 BTC")
-
-    val zeroBitcoins = Bitcoins(0)
-    zeroBitcoins.toString must be ("0 BTC")
-  }
-
-  it must "display satoshis correctly" in {
-    val satoshis = Satoshis(1)
-    satoshis.toString must be ("1 Satoshis")
-  }
-
-  it must "display bits correctly" in {
-    val bits = Bits(5.23)
-    bits.toString must be ("5.23 Bits")
-  }
-
-  it must "display milliBits correctly" in {
-    val milliBits = MilliBitcoins(1.232312352)
-    milliBits.toString must be ("1.23232 mBTC")
-  }
-
-  it must "say that 1 BTC is equal to 100,000,000 satoshis" in {
-
-    val satoshis = Satoshis(100000000)
-    (satoshis == CurrencyUnits.oneBTC) must be (true)
-  }
-
-  it must "throw a requirement failed exception when instantiating satoshis with a double with decimal points" in {
-    val invalidSatoshis = 1.11111
-    intercept[IllegalArgumentException] {
-      Satoshis(invalidSatoshis)
-    }
-  }
-
-  it must "evaluate one satoshis is less than one millibit" in {
-    (CurrencyUnits.oneSatoshi < CurrencyUnits.oneMilliBit) must be (true)
-  }
-
-  it must "evalute one satoshi is less than or equal to one satoshis" in {
-    (CurrencyUnits.oneSatoshi <= CurrencyUnits.oneSatoshi) must be (true)
-  }
-
-  it must "say one BTC is greater than one hundred millibit" in {
-    (CurrencyUnits.oneBTC > CurrencyUnits.oneHundredMilliBits) must be (true)
-  }
-
-  it must "say one satoshis is greater than or equal to one satoshis" in {
-    (CurrencyUnits.oneSatoshi >= CurrencyUnits.oneSatoshi) must be (true)
-  }
-
-  it must "say one satoshis is not equal to one btc" in {
-    (CurrencyUnits.oneSatoshi != CurrencyUnits.oneBTC) must be (true)
-  }
-
-  it must "add one satoshis to another satoshi" in {
-    (CurrencyUnits.oneSatoshi + CurrencyUnits.oneSatoshi).value must be (2)
-  }
-
-  it must "subtract one satoshi from one satoshi" in {
-    (CurrencyUnits.oneSatoshi - CurrencyUnits.oneSatoshi).value must be (0)
-  }
-
-  it must "multiply one satoshi by one satoshis" in {
-    (CurrencyUnits.oneSatoshi * CurrencyUnits.oneSatoshi).value must be (1)
+  it must "have the correct number for zero units of currency" in {
+    CurrencyUnits.zero.underlying must be (Int64.zero)
   }
 
 }

--- a/src/test/scala/org/bitcoins/core/protocol/blockchain/ChainParamsTest.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/blockchain/ChainParamsTest.scala
@@ -1,9 +1,10 @@
 package org.bitcoins.core.protocol.blockchain
 
-import org.bitcoins.core.currency.{Bitcoins, CurrencyUnits}
+import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.number.Int64
 import org.bitcoins.core.protocol.script.{ScriptPubKey, ScriptSignature}
 import org.bitcoins.core.protocol.transaction.{TransactionConstants, TransactionInput, TransactionOutput}
-import org.bitcoins.core.util.{Base58, BitcoinSLogger, BitcoinSUtil}
+import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil}
 import org.scalatest.{FlatSpec, MustMatchers}
 
 /**
@@ -17,7 +18,7 @@ class ChainParamsTest extends FlatSpec with MustMatchers with BitcoinSLogger {
   val expectedGenesisScriptSig = ScriptSignature("04FFFF001D0104455468652054696D65732030332F4A616E2F32303039204368616E63656C6C6F72206F6E206272696E6B206F66207365636F6E64206261696C6F757420666F722062616E6B73".toLowerCase())
   val expectedGenesisInput = TransactionInput(expectedGenesisScriptSig)
   val expectedGenesisScriptPubKey = ScriptPubKey("4104678AFDB0FE5548271967F1A67130B7105CD6A828E03909A67962E0EA1F61DEB649F6BC3F4CEF38C4F35504E51EC112DE5C384DF7BA0B8D578A4C702B6BF11D5FAC".toLowerCase)
-  val expectedGenesisOutput = TransactionOutput(CurrencyUnits.toSatoshis(Bitcoins(50)),expectedGenesisScriptPubKey)
+  val expectedGenesisOutput = TransactionOutput(Satoshis(Int64(5000000000L)),expectedGenesisScriptPubKey)
   "ChainParams" must "generate correct block hex for genesis block" in {
     val hex = "0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e6" +
       "7768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c010100000001000000000000000000000000000" +
@@ -51,7 +52,7 @@ class ChainParamsTest extends FlatSpec with MustMatchers with BitcoinSLogger {
 
   it must "generate the output correctly for the genesis transaction's output" in {
     val output = genesisTransaction.outputs.head
-    output.value must be (Bitcoins(50))
+    output.value must be (Satoshis(Int64(5000000000L)))
     output.scriptPubKey.hex must be (expectedGenesisScriptPubKey.hex)
     output.hex must be ("0100F2052A0100000043".toLowerCase + expectedGenesisScriptPubKey.hex)
   }

--- a/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionOutputFactoryTest.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionOutputFactoryTest.scala
@@ -1,8 +1,8 @@
 package org.bitcoins.core.protocol.transaction
 
-import org.bitcoins.core.currency.CurrencyUnits
+import org.bitcoins.core.currency.{CurrencyUnits, Satoshis}
 import org.bitcoins.core.util.TestUtil
-import org.scalatest.{MustMatchers, FlatSpec}
+import org.scalatest.{FlatSpec, MustMatchers}
 
 /**
  * Created by chris on 3/30/16.
@@ -16,8 +16,8 @@ class TransactionOutputFactoryTest extends FlatSpec with MustMatchers {
   }
 
   it must "modify the currency unit for a tx output" in {
-    val newTxOutput = TransactionOutput(EmptyTransactionOutput,CurrencyUnits.oneSatoshi)
-    newTxOutput.value must be (CurrencyUnits.oneSatoshi)
+    val newTxOutput = TransactionOutput(EmptyTransactionOutput,Satoshis.one)
+    newTxOutput.value must be (Satoshis.one)
   }
 
   it must "modify the scriptPubKey for a tx output" in {

--- a/src/test/scala/org/bitcoins/core/serializers/RawSatoshisSerializerSpec.scala
+++ b/src/test/scala/org/bitcoins/core/serializers/RawSatoshisSerializerSpec.scala
@@ -1,0 +1,17 @@
+package org.bitcoins.core.serializers
+
+import org.bitcoins.core.currency.{CurrencyUnitGenerator, Satoshis}
+import org.scalacheck.{Prop, Properties}
+
+/**
+  * Created by chris on 6/23/16.
+  */
+class RawSatoshisSerializerSpec extends Properties("RawSatoshiSerializerSpec") {
+
+  property("Symmetrical serialization") =
+    Prop.forAll(CurrencyUnitGenerator.satoshis) { satoshis =>
+      Satoshis(satoshis.hex) == satoshis
+
+    }
+
+}

--- a/src/test/scala/org/bitcoins/core/serializers/transaction/RawTransactionOutputParserTest.scala
+++ b/src/test/scala/org/bitcoins/core/serializers/transaction/RawTransactionOutputParserTest.scala
@@ -2,7 +2,8 @@
 package org.bitcoins.core.serializers.transaction
 
 
-import org.bitcoins.core.currency.{Bitcoins, CurrencyUnits, Satoshis}
+import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.number.Int64
 import org.bitcoins.core.protocol.transaction.{EmptyTransactionOutput, TransactionOutput}
 import org.bitcoins.core.script.bitwise.OP_EQUAL
 import org.bitcoins.core.script.constant.{BytesToPushOntoStack, ScriptConstant}
@@ -23,8 +24,8 @@ class RawTransactionOutputParserTest extends FlatSpec with MustMatchers with Raw
     val txOutput : Seq[TransactionOutput] = read(rawTxOutput)
     val firstOutput = txOutput.head
     val secondOutput = txOutput(1)
-    firstOutput.value must be (CurrencyUnits.toSatoshis(Bitcoins(0.0002)))
-    secondOutput.value must be (CurrencyUnits.toSatoshis(Bitcoins(0.02981145)))
+    firstOutput.value must be (Satoshis(Int64(20000)))
+    secondOutput.value must be (Satoshis(Int64(2981145)))
     firstOutput.scriptPubKey.asm must be (Seq(OP_HASH160, BytesToPushOntoStack(20),ScriptConstant("eda8ae08b5c9f973f49543e90a7c292367b3337c"), OP_EQUAL))
     secondOutput.scriptPubKey.asm must be (Seq(OP_HASH160,BytesToPushOntoStack(20), ScriptConstant("be2319b9060429692ebeffaa3be38497dc5380c8"), OP_EQUAL))
   }
@@ -45,7 +46,7 @@ class RawTransactionOutputParserTest extends FlatSpec with MustMatchers with Raw
     //https://bitcoin.stackexchange.com/questions/2859/how-are-transaction-hashes-calculated
     val txOutput = "0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac"
     val output = RawTransactionOutputParser.read(txOutput)
-    output.head.value must be (Satoshis(5000000000L))
+    output.head.value must be (Satoshis(Int64(5000000000L)))
   }
 
   it must "read a two serialized ouptuts" in {

--- a/src/test/scala/org/bitcoins/core/util/TransactionTestUtil.scala
+++ b/src/test/scala/org/bitcoins/core/util/TransactionTestUtil.scala
@@ -45,7 +45,7 @@ trait TransactionTestUtil extends BitcoinSLogger {
     val outpoint = TransactionOutPoint(EmptyTransactionOutPoint.txId,0xFFFFFFFF)
     val scriptSignature = ScriptSignature("0000")
     val input = TransactionInput(outpoint,scriptSignature,TransactionConstants.sequence)
-    val output = TransactionOutput(CurrencyUnits.zeroSatoshis,scriptPubKey)
+    val output = TransactionOutput(CurrencyUnits.zero,scriptPubKey)
 
     val tx = Transaction(TransactionConstants.version,Seq(input),Seq(output),TransactionConstants.lockTime)
     (tx,0)
@@ -74,7 +74,7 @@ trait TransactionTestUtil extends BitcoinSLogger {
 
     val outpoint = TransactionOutPoint(creditingTx.txId,outputIndex)
     val input = TransactionInput(outpoint,scriptSignature,TransactionConstants.sequence)
-    val output = TransactionOutput(CurrencyUnits.zeroSatoshis,EmptyScriptPubKey)
+    val output = TransactionOutput(CurrencyUnits.zero,EmptyScriptPubKey)
     val tx = Transaction(TransactionConstants.version,Seq(input),Seq(output),TransactionConstants.lockTime)
 /*    val expectedHex = "01000000019ce5586f04dd407719ab7e2ed3583583b9022f29652702cfac5ed082013461fe000000004847304402200a5c6163f07b8d3b013c4d1d6dba25e780b39658d79ba37af7057a3b7f15ffa102201fd9b4eaa9943f734928b99a83592c2e7bf342ea2680f6a2bb705167966b742001ffffffff0100000000000000000000000000"
     require(tx.hex == expectedHex,"\nExpected hex: " + expectedHex + "\nActual hex:   " +  tx.hex)*/


### PR DESCRIPTION
Redesigning `CurrencyUnit` to be a trait with one sub class `Satoshis`. `Satoshis` now uses a type alias, the implementation type being `Int64` which is what it is in the Bitcoin Core code base. 
