### PR TITLE
2019 05 01 wallet ammonite scripts pt2

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,16 @@
+## Ammonite scripts
+
+This project contain [Ammonite](https://ammonite.io) scripts that demonstrate
+functionality of `bitcoin-s`.
+
+#### Running them with sbt:
+
+```bash
+$ sbt "doc/run path/to/script.sc" # this is very slow, not recommended
+```
+
+#### Running them with the [Bloop CLI](https://scalacenter.github.io/bloop/):
+
+```bash
+$ bloop run doc --args path/to/script.sc # much faster than through sbt
+```

--- a/doc/src/main/scala/org/bitcoins/doc/AmmoniteBridge.scala
+++ b/doc/src/main/scala/org/bitcoins/doc/AmmoniteBridge.scala
@@ -1,7 +1,43 @@
 package org.bitcoins.doc
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import scala.util.Properties
 
 object amm extends App {
-  override def main(args: Array[String]): Unit = {
+
+  /** Gets all files ending with .sc in dir or subdirs */
+  def getScripts(dir: Path): Seq[Path] = {
+    import scala.collection.JavaConverters._
+
+    Files
+      .walk(dir)
+      .iterator()
+      .asScala
+      .filter(Files.isRegularFile(_))
+      .filter(_.toString.endsWith(".sc"))
+      .toList
+  }
+
+  if (args.isEmpty || args.headOption.forall(_.isEmpty)) {
+    import System.err.{println => printerr}
+
+    printerr("No script name provided!")
+    printerr()
+
+    val cwd = Paths.get(Properties.userDir)
+    val scripts = getScripts(cwd)
+
+    if (scripts.nonEmpty) {
+      printerr("Available scripts:")
+      scripts.foreach { script =>
+        printerr(s"  ${cwd.relativize(script)}")
+      }
+    } else {
+      printerr("No .sc scripts found!")
+    }
+    sys.exit(1)
+  } else {
     ammonite.Main.main(args)
   }
 }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -53,6 +53,7 @@ object Deps {
     val slickHikari = "com.typesafe.slick" %% "slick-hikaricp" % V.slickV
     val sqlite = "org.xerial" % "sqlite-jdbc" % V.sqliteV
     val postgres = "org.postgresql" % "postgresql" % V.postgresV
+    val ammonite = "com.lihaoyi" %% "ammonite" % V.ammoniteV cross CrossVersion.full
   }
 
   object Test {
@@ -67,7 +68,7 @@ object Deps {
     val spray = "io.spray" %% "spray-json" % V.spray % "test" withSources () withJavadoc ()
     val akkaHttp = "com.typesafe.akka" %% "akka-http-testkit" % V.akkav % "test" withSources () withJavadoc ()
     val akkaStream = "com.typesafe.akka" %% "akka-stream-testkit" % V.akkaStreamv % "test" withSources () withJavadoc ()
-    val ammonite = "com.lihaoyi" %% "ammonite" % V.ammoniteV % "test" cross CrossVersion.full
+    val ammonite = Compile.ammonite % "test"
     val playJson = Compile.playJson % "test"
     val akkaTestkit = "com.typesafe.akka" %% "akka-testkit" % V.akkaActorV withSources () withJavadoc ()
   }
@@ -203,7 +204,7 @@ object Deps {
   )
 
   val doc = List(
-    "com.lihaoyi" %% "ammonite" % V.ammoniteV cross CrossVersion.full,
+    Compile.ammonite,
     "ch.qos.logback" % "logback-classic" % V.logback withSources () withJavadoc (),
     Test.scalaTest,
     Test.logback


### PR DESCRIPTION
Sample output when running with no script name provided: 

```
~/dev/scala/bitcoin-s 2019-05-01-wallet-ammonite-scripts-pt2*
❮ bloop run doc 
[E] No script name provided!
[E] 
[E] Available scripts:
[E]   src/main/scala/org/bitcoins/doc/wallet/create-wallet.sc
```