### PR TITLE
Implemented an example external tag

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/AddressTag.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/AddressTag.scala
@@ -13,8 +13,8 @@ trait AddressTagType {
 trait AddressTagName {
   def name: String
 
-  def ==(at: AddressTagType): Boolean = name == at.typeName
-  def !=(at: AddressTagType): Boolean = !(this == at)
+  def ==(at: AddressTagName): Boolean = name == at.name
+  def !=(at: AddressTagName): Boolean = !(this == at)
 }
 
 /**

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/ExampleExternalTag.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/ExampleExternalTag.scala
@@ -1,0 +1,49 @@
+package org.bitcoins.core.wallet.utxo
+
+case object ExampleTagType extends ExternalAddressTagType {
+  override val typeName: String = "ExampleType"
+}
+
+sealed trait ExampleExternalTag extends ExternalAddressTag {
+  override val tagType: ExternalAddressTagType = ExampleTagType
+}
+
+object ExampleExternalTag extends AddressTagFactory[ExampleExternalTag] {
+  override val tagType: ExternalAddressTagType = ExampleTagType
+
+  override val tagNames: Vector[ExternalAddressTagName] =
+    Vector(ExampleNameA, ExampleNameB, ExampleNameC)
+
+  override val all: Vector[ExampleExternalTag] =
+    Vector(ExampleTagA, ExampleTagB, ExampleTagC)
+
+  case object ExampleNameA extends ExternalAddressTagName {
+    override val name: String = "A"
+  }
+
+  case object ExampleNameB extends ExternalAddressTagName {
+    override val name: String = "B"
+  }
+
+  case object ExampleNameC extends ExternalAddressTagName {
+    override val name: String = "C"
+  }
+
+  case object ExampleTagA extends ExampleExternalTag {
+    override val tagName: ExternalAddressTagName = ExampleNameA
+  }
+
+  case object ExampleTagB extends ExampleExternalTag {
+    override val tagName: ExternalAddressTagName = ExampleNameB
+  }
+
+  case object ExampleTagC extends ExampleExternalTag {
+    override val tagName: ExternalAddressTagName = ExampleNameC
+  }
+}
+
+object Example {
+
+  val redundancyWithinTypeExternalAddressTag: Boolean = // Returns True
+    ExternalAddressTagWrapper("A", "ExampleType") == ExampleExternalTag.ExampleTagA
+}


### PR DESCRIPTION
I don't see what making `ExternalTagWrapper` extend `ExternalAddressTag` accomplishes other than the following bad property